### PR TITLE
Update iconsur compatibility for macOS Monterey without Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ The generation is based on the most related iOS app from the App Store, or, if t
 
 ![image](https://user-images.githubusercontent.com/5051300/85926574-ebfb9d80-b8d2-11ea-836b-28e38d1f3447.png)
 
+## Requirements
+
+Install the Python3 dependencies:
+
+```
+pip install pyobjc-core
+pip pyobjc-framework-Cocoa
+pip pyobjc-framework-Quartz
+```
+
 ## Installation
 Install it easily:
 

--- a/src/fileicon.sh
+++ b/src/fileicon.sh
@@ -200,7 +200,7 @@ setCustomIcon() {
   # !!
   # !! Note: setIcon_forFile_options_() seemingly always indicates True, even with invalid image files, so
   # !!       we attempt no error handling in the Python code.
-  /usr/bin/python - "$imgFile" "$fileOrFolder" <<'EOF' || return
+  /usr/bin/python3 - "$imgFile" "$fileOrFolder" <<'EOF' || return
 import Cocoa
 import sys
 


### PR DESCRIPTION
Primary changes:

- Changed /usr/bin/python to /usr/bin/python3
- Added requirements in readme
- Adapted setIcon line for Python3